### PR TITLE
Revert add of tripleo-ssl

### DIFF
--- a/requirements/cira-requirements.txt
+++ b/requirements/cira-requirements.txt
@@ -15,4 +15,3 @@ git+https://github.com/redhat-openstack/ansible-role-tripleo-overcloud-prep-bare
 git+https://github.com/redhat-openstack/ansible-role-tripleo-provision-heat.git#egg=ansible-role-tripleo-provision-heat
 git+https://github.com/redhat-openstack/ansible-role-tripleo-validate-ipmi.git#egg=ansible-role-tripleo-validate-ipmi
 ara
-git+https://github.com/redhat-openstack/ansible-role-tripleo-ssl.git#egg=ansible-role-tripleo-ssl


### PR DESCRIPTION
tripleo-ssl is actually now overcloud-ssl and is handled
via the quickstart-extras-requirements.txt which I've
added to the jenkins-jobs repo.